### PR TITLE
Add leafnode sys bridge example

### DIFF
--- a/examples/topologies/leafnode-sys-bridge/cli/Dockerfile
+++ b/examples/topologies/leafnode-sys-bridge/cli/Dockerfile
@@ -1,0 +1,12 @@
+FROM natsio/nats-box:0.12.0
+
+ADD https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 /usr/local/bin/jq
+RUN chmod +x /usr/local/bin/jq
+
+# Copy nats-server from source image.
+COPY --from=synadia/nats-server:nightly /bin/nats-server /usr/local/bin/
+
+COPY . .
+
+CMD ["main.sh"]
+

--- a/examples/topologies/leafnode-sys-bridge/cli/Dockerfile
+++ b/examples/topologies/leafnode-sys-bridge/cli/Dockerfile
@@ -4,9 +4,8 @@ ADD https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 /usr/loca
 RUN chmod +x /usr/local/bin/jq
 
 # Copy nats-server from source image.
-COPY --from=synadia/nats-server:nightly /bin/nats-server /usr/local/bin/
+COPY --from=nats:2.8.4-alpine /usr/local/bin/nats-server /usr/local/bin/
 
 COPY . .
 
 CMD ["main.sh"]
-

--- a/examples/topologies/leafnode-sys-bridge/cli/main.sh
+++ b/examples/topologies/leafnode-sys-bridge/cli/main.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+
+set -xeuo pipefail
+
+NATS_HUB_URL="nats://0.0.0.0:4222"
+NATS_LEAF1_URL="nats://0.0.0.0:4223"
+NATS_LEAF2_URL="nats://0.0.0.0:4224"
+
+# ### Hub setup
+# Create the operator, generate a signing key (which is a best practice),
+# and initialize the default SYS account and sys user.
+nsc add operator \
+  --generate-signing-key \
+  --sys hub
+
+# A follow-up edit of the operator enforces signing keys are used for
+# accounts as well. Setting the server URL is a convenience so that
+# it does not need to be specified with call `nsc push` while
+# the operator is set in the `nsc` environment.
+nsc edit operator \
+  --require-signing-keys \
+  --account-jwt-server-url \
+  "$NATS_HUB_URL"
+
+# For this example, we are demonstrating how we can create
+# a user which can be used in a leaf node remote and bound
+# to the leaf system account.
+nsc add account OPS
+
+nsc edit account OPS \
+  --sk generate
+
+nsc add user \
+  --account OPS ops
+
+# Finally, generate the config for the server.
+nsc generate config \
+  --nats-resolver \
+  --sys-account SYS > hub-resolver.conf
+
+# ### Leaf nodes
+# Create the operators and system accounts for the leaf nodes.
+# No additional accounts or users are required for this example.
+nsc add operator \
+  --generate-signing-key \
+  --sys leaf1
+
+nsc edit operator \
+  --require-signing-keys \
+  --account-jwt-server-url \
+  "$NATS_LEAF1_URL"
+
+nsc generate config \
+  --nats-resolver \
+  --sys-account SYS > leaf1-resolver.conf
+
+# Extract the full ID of the system account to specify in the
+# remote.
+LEAF1_SYS_ID=$(nsc describe account --json SYS| jq -r .sub)
+
+nsc add operator \
+  --generate-signing-key \
+  --sys leaf2
+
+nsc edit operator \
+  --require-signing-keys \
+  --account-jwt-server-url \
+  "$NATS_LEAF2_URL"
+
+nsc generate config \
+  --nats-resolver \
+  --sys-account SYS > leaf2-resolver.conf
+
+LEAF2_SYS_ID=$(nsc describe account --json SYS| jq -r .sub)
+
+# Create the hub configuration with leaf nodes enabled.
+echo 'Creating the hub server conf...'
+cat <<- EOF > hub.conf
+server_name: hub
+port: 4222
+leafnodes: {
+  port: 7422
+}
+
+include hub-resolver.conf
+EOF
+
+# Create the two leaf node configurations each with respective
+# resolver config.
+echo 'Creating the leaf1 node conf...'
+cat <<- EOF > leaf1.conf
+server_name: leaf1
+port: 4223
+leafnodes: {
+  remotes: [
+    {
+      url: "nats-leaf://0.0.0.0:7422",
+      credentials: "$NKEYS_PATH/creds/hub/OPS/ops.creds",
+      account: ${LEAF1_SYS_ID},
+    }
+  ]
+}
+
+include leaf1-resolver.conf
+EOF
+
+echo 'Creating the leaf2 node conf...'
+cat <<- EOF > leaf2.conf
+server_name: leaf2
+port: 4224
+leafnodes: {
+  remotes: [
+    {
+      url: "nats-leaf://0.0.0.0:7422",
+      credentials: "$NKEYS_PATH/creds/hub/OPS/ops.creds",
+      account: ${LEAF2_SYS_ID},
+    }
+  ]
+}
+
+include leaf2-resolver.conf
+EOF
+
+# Start the hub server first.
+nats-server -c hub.conf > /dev/null 2>&1 &
+HUB_PID=$!
+
+sleep 1
+
+# Push the OPS account.
+nsc env -o hub > /dev/null
+nsc push -a OPS
+
+# Now start the two leaf nodes and ensure they startup.
+nats-server -c leaf1.conf > /dev/null 2>&1 &
+LEAF1_PID=$!
+
+nats-server -c leaf2.conf > /dev/null 2>&1 &
+LEAF2_PID=$!
+
+sleep 2
+
+# Define a context which connects to the hub using
+# the ops user.
+nsc env -o hub > /dev/null
+nats context save \
+  --server=$NATS_HUB_URL \
+  --nsc=nsc://hub/OPS/ops \
+  hub-ops
+
+# Doing a server list will report on the leaf nodes and
+# will not include the hub.
+nats --context=hub-ops server list
+
+kill $LEAF1_PID
+kill $LEAF2_PID
+kill $HUB_PID

--- a/examples/topologies/leafnode-sys-bridge/cli/main.sh
+++ b/examples/topologies/leafnode-sys-bridge/cli/main.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -xeuo pipefail
+set -euo pipefail
 
 NATS_HUB_URL="nats://0.0.0.0:4222"
 NATS_LEAF1_URL="nats://0.0.0.0:4223"
@@ -128,7 +128,7 @@ HUB_PID=$!
 sleep 1
 
 # Push the OPS account.
-nsc env -o hub > /dev/null
+nsc env -o hub 2> /dev/null
 nsc push -a OPS
 
 # Now start the two leaf nodes and ensure they startup.
@@ -142,7 +142,7 @@ sleep 2
 
 # Define a context which connects to the hub using
 # the ops user.
-nsc env -o hub > /dev/null
+nsc env -o hub 2> /dev/null
 nats context save \
   --server=$NATS_HUB_URL \
   --nsc=nsc://hub/OPS/ops \

--- a/examples/topologies/leafnode-sys-bridge/docker-compose.yaml
+++ b/examples/topologies/leafnode-sys-bridge/docker-compose.yaml
@@ -2,6 +2,3 @@ version: '3.9'
 services:
   app:
     image: ${IMAGE_TAG}
-    ports:
-      - "14222:4222"
-      - "14223:4223"

--- a/examples/topologies/leafnode-sys-bridge/docker-compose.yaml
+++ b/examples/topologies/leafnode-sys-bridge/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3.9'
+services:
+  app:
+    image: ${IMAGE_TAG}
+    ports:
+      - "14222:4222"
+      - "14223:4223"

--- a/examples/topologies/leafnode-sys-bridge/meta.yaml
+++ b/examples/topologies/leafnode-sys-bridge/meta.yaml
@@ -1,0 +1,9 @@
+title: Leafnode System Account Bridge
+description: |-
+  This examples demonstrates how to create user in a remote, e.g.
+  the hub cluster, and use it within a remote connection in a leaf
+  node bound to the local system account.
+
+  The effect is that this user can then connect to the hub and
+  report on the leaf nodes as if the system account was being
+  used.


### PR DESCRIPTION
@jnmoyne I believe this is what Kevin asked for.. hub user that can bridge the system account in leaf nodes. Here is the [output](https://nats-by-example-2hkslhi6t-connecteverything.vercel.app/examples/topologies/leafnode-sys-bridge/cli#output). If you scroll to the bottom the `nats server list` reports the leaf nodes.