### PR TITLE
Add example with multiple subscription and one iterator

### DIFF
--- a/examples/messaging/meta.yaml
+++ b/examples/messaging/meta.yaml
@@ -12,3 +12,4 @@ examples:
   - request-reply
   - json
   - concurrent
+  - multiple-subjects-subscription

--- a/examples/messaging/multiple-subjects-subscription/meta.yaml
+++ b/examples/messaging/multiple-subjects-subscription/meta.yaml
@@ -1,4 +1,4 @@
-title: Iterating over many subscriptions
+title: Iterating Over Multiple Subscriptions
 description: |-
   Core NATS subscription support flexible subject model with tokens and wildcards, 
   but there are cases that require setting up separate subscriptions

--- a/examples/messaging/multiple-subjects-subscription/meta.yaml
+++ b/examples/messaging/multiple-subjects-subscription/meta.yaml
@@ -1,0 +1,6 @@
+title: Iterating over many subscriptions
+description: |-
+  Core NATS subscription support flexible subject model with tokens and wildcards, but there are cases (i.e. user want `transport.cars`, `transport.planes` and `transport.ships`, but not `transport.spaceships`) that require setting up separate subscriptions.
+
+  Such approach works and is performant, but not very convinient when reading the messages.
+  This example shows how to achieve required behaviour without sacrificing usability.

--- a/examples/messaging/multiple-subjects-subscription/meta.yaml
+++ b/examples/messaging/multiple-subjects-subscription/meta.yaml
@@ -4,5 +4,5 @@ description: |-
   but there are cases that require setting up separate subscriptions
   (i.e. user want `transport.cars`, `transport.planes` and `transport.ships`, but not `transport.spaceships`). 
 
-  Such approach works and is performant, but not very convinient when reading the messages.
+  Such approach works and is performant, but not very convenient when reading the messages.
   This example shows how to achieve required behaviour without sacrificing usability.

--- a/examples/messaging/multiple-subjects-subscription/meta.yaml
+++ b/examples/messaging/multiple-subjects-subscription/meta.yaml
@@ -1,6 +1,8 @@
 title: Iterating over many subscriptions
 description: |-
-  Core NATS subscription support flexible subject model with tokens and wildcards, but there are cases (i.e. user want `transport.cars`, `transport.planes` and `transport.ships`, but not `transport.spaceships`) that require setting up separate subscriptions.
+  Core NATS subscription support flexible subject model with tokens and wildcards, 
+  but there are cases that require setting up separate subscriptions
+  (i.e. user want `transport.cars`, `transport.planes` and `transport.ships`, but not `transport.spaceships`). 
 
   Such approach works and is performant, but not very convinient when reading the messages.
   This example shows how to achieve required behaviour without sacrificing usability.

--- a/examples/messaging/multiple-subjects-subscription/rust/main.rs
+++ b/examples/messaging/multiple-subjects-subscription/rust/main.rs
@@ -1,0 +1,63 @@
+use std::{env, str::from_utf8};
+
+use futures::stream::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), async_nats::Error> {
+    // Use the NATS_URL env variable if defined, otherwise fallback
+    // to the default.
+    let nats_url = env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string());
+
+    let client = async_nats::connect(nats_url).await?;
+
+    // Core NATS `client.subscribe()` can subscribe to more than one explicit subject using
+    // `>` and `*` wildcards, but not to two distinct subjects.
+    // However, it's still possible to have just one stream of messages for such case.
+    //
+    // First, let's subscribe to those subjects.
+    let subscription_cars = client.subscribe("cars.>".into()).await?;
+    let subscription_planes = client.subscribe("planes.>".into()).await?;
+
+    // Then, spawn two tasks that publishes to both subject at the same time.
+    tokio::task::spawn({
+        let client = client.clone();
+        async move {
+            for i in 0..100 {
+                client
+                    .publish(format!("cars.{}", i), format!("car number {}", i).into())
+                    .await?;
+            }
+            Ok::<(), async_nats::Error>(())
+        }
+    });
+    tokio::task::spawn({
+        let client = client.clone();
+        async move {
+            for i in 0..100 {
+                client
+                    .publish(
+                        format!("planes.{}", i),
+                        format!("plane number {}", i).into(),
+                    )
+                    .await?;
+            }
+            Ok::<(), async_nats::Error>(())
+        }
+    });
+
+    // Now, let's create the cars stream that will receive messages from both subscriptions.
+    // If you need more than two subscriptions, consider using `futures::stream::select_all`.
+    // We also leverage the `take()` combinator to limit number of messages we want to get in total.
+    let mut messages = futures::stream::select(subscription_cars, subscription_planes).take(200);
+
+    // Receive the messages from both subjects.
+    while let Some(message) = messages.next().await {
+        println!(
+            "received message on subject {} with paylaod {}",
+            message.subject,
+            from_utf8(&message.payload)?
+        );
+    }
+
+    Ok(())
+}

--- a/examples/messaging/multiple-subjects-subscription/rust/main.rs
+++ b/examples/messaging/multiple-subjects-subscription/rust/main.rs
@@ -11,20 +11,32 @@ async fn main() -> Result<(), async_nats::Error> {
     let client = async_nats::connect(nats_url).await?;
 
     // Core NATS `client.subscribe()` can subscribe to more than one explicit subject using
-    // `>` and `*` wildcards, but not to two distinct subjects.
-    // However, it's still possible to have just one stream of messages for such case.
+    // `>` and `*` wildcards, but not to two or more distinct subjects.
+    // However, it's still possible to have just one stream of messages for such use case.
     //
-    // First, let's subscribe to those subjects.
+    // First, let's subscribe to desired subjects.
     let subscription_cars = client.subscribe("cars.>".into()).await?;
     let subscription_planes = client.subscribe("planes.>".into()).await?;
+    let subscription_ships = client.subscribe("ships.>".into()).await?;
 
-    // Then, spawn two tasks that publishes to both subject at the same time.
+    // Then, spawn three tasks that publishes to each subject at the same time.
     tokio::task::spawn({
         let client = client.clone();
         async move {
             for i in 0..100 {
                 client
                     .publish(format!("cars.{}", i), format!("car number {}", i).into())
+                    .await?;
+            }
+            Ok::<(), async_nats::Error>(())
+        }
+    });
+    tokio::task::spawn({
+        let client = client.clone();
+        async move {
+            for i in 0..100 {
+                client
+                    .publish(format!("ships.{}", i), format!("ship number {}", i).into())
                     .await?;
             }
             Ok::<(), async_nats::Error>(())
@@ -45,10 +57,14 @@ async fn main() -> Result<(), async_nats::Error> {
         }
     });
 
-    // Now, let's create the cars stream that will receive messages from both subscriptions.
-    // If you need more than two subscriptions, consider using `futures::stream::select_all`.
+    // Now, let's create the stream that will receive messages from all subscriptions.
     // We also leverage the `take()` combinator to limit number of messages we want to get in total.
-    let mut messages = futures::stream::select(subscription_cars, subscription_planes).take(200);
+    //
+    // If you need to get messages from at most two subscriptions, `futures::stream::select` can be
+    // used instead.
+    let mut messages =
+        futures::stream::select_all([subscription_cars, subscription_planes, subscription_ships])
+            .take(300);
 
     // Receive the messages from both subjects.
     while let Some(message) = messages.next().await {


### PR DESCRIPTION
I was asked quite a lot if it’s possible to have one subscription to two distinct subjects that can’t be covered by wildcards.

This example covers that case.