### PR TITLE
Bumping async-nats version for TSL bypass concern

### DIFF
--- a/docker/rust/Cargo.toml
+++ b/docker/rust/Cargo.toml
@@ -8,7 +8,7 @@ name = "app"
 path = "main.rs"
 
 [dependencies]
-async-nats = "0.28.0"
+async-nats = "0.29.0"
 tokio = { version = "1.20.0", features = ["full"] }
 futures = "0.3.21"
 serde_json = "1.0.82"


### PR DESCRIPTION
This is a (hopefully) simple update to resolve the complaint by depdendabot here: 

https://github.com/ConnectEverything/nats-by-example/security/dependabot/7