### PR TITLE
Add unique store_dir to jetstream blocks.

### DIFF
--- a/examples/topologies/supercluster-jetstream/cli/main.sh
+++ b/examples/topologies/supercluster-jetstream/cli/main.sh
@@ -29,7 +29,9 @@ server_name: n1
 
 include sys.conf
 
-jetstream: {}
+jetstream: {
+  store_dir: /tmp/nats/storage/n1
+}
 
 cluster: {
   name: east,
@@ -57,7 +59,9 @@ server_name: n2
 
 include sys.conf
 
-jetstream: {}
+jetstream: {
+  store_dir: /tmp/nats/storage/n2
+}
 
 cluster: {
   name: central,
@@ -86,7 +90,9 @@ server_name: n3
 
 include sys.conf
 
-jetstream: {}
+jetstream: {
+  store_dir: /tmp/nats/storage/n3
+}
 
 cluster: {
   name: west,

--- a/examples/use-cases/cross-region-streams-cluster/cli/main.sh
+++ b/examples/use-cases/cross-region-streams-cluster/cli/main.sh
@@ -56,6 +56,9 @@ cluster: {
   port: 6222
   include cluster.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az1
+}
 EOF
 
 cat <<- EOF > "rg1-az2.conf"
@@ -66,6 +69,9 @@ include shared.conf
 cluster: {
   port: 6223
   include cluster.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az2
 }
 EOF
 
@@ -78,6 +84,9 @@ cluster: {
   port: 6224
   include cluster.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az3
+}
 EOF
 
 cat <<- EOF > "rg2-az1.conf"
@@ -88,6 +97,9 @@ include shared.conf
 cluster: {
   port: 6225
   include cluster.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az1
 }
 EOF
 
@@ -100,6 +112,9 @@ cluster: {
   port: 6226
   include cluster.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az2
+}
 EOF
 
 cat <<- EOF > "rg2-az3.conf"
@@ -110,6 +125,9 @@ include shared.conf
 cluster: {
   port: 6227
   include cluster.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az3
 }
 EOF
 
@@ -122,6 +140,9 @@ cluster: {
   port: 6228
   include cluster.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az1
+}
 EOF
 
 cat <<- EOF > "rg3-az2.conf"
@@ -133,6 +154,9 @@ cluster: {
   port: 6229
   include cluster.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az2
+}
 EOF
 
 cat <<- EOF > "rg3-az3.conf"
@@ -143,6 +167,9 @@ include shared.conf
 cluster: {
   port: 6230
   include cluster.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az3
 }
 EOF
 

--- a/examples/use-cases/cross-region-streams-supercluster/cli/main.sh
+++ b/examples/use-cases/cross-region-streams-supercluster/cli/main.sh
@@ -87,6 +87,9 @@ gateway {
   port: 7222
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az1
+}
 EOF
 
 cat <<- EOF > "rg1-az2.conf"
@@ -108,6 +111,9 @@ gateway {
   port: 7223
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az2
+}
 EOF
 
 cat <<- EOF > "rg1-az3.conf"
@@ -128,6 +134,9 @@ gateway {
   name: rg1
   port: 7224
   include gateway-routes.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az3
 }
 EOF
 
@@ -152,6 +161,9 @@ gateway {
   port: 7225
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az1
+}
 EOF
 
 cat <<- EOF > "rg2-az2.conf"
@@ -173,6 +185,9 @@ gateway {
   port: 7226
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az2
+}
 EOF
 
 cat <<- EOF > "rg2-az3.conf"
@@ -193,6 +208,9 @@ gateway {
   name: rg2
   port: 7227
   include gateway-routes.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az3
 }
 EOF
 
@@ -217,6 +235,9 @@ gateway {
   port: 7228
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az1
+}
 EOF
 
 cat <<- EOF > "rg3-az2.conf"
@@ -238,6 +259,9 @@ gateway {
   port: 7229
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az2
+}
 EOF
 
 cat <<- EOF > "rg3-az3.conf"
@@ -258,6 +282,9 @@ gateway {
   name: rg3
   port: 7230
   include gateway-routes.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az3
 }
 EOF
 
@@ -284,6 +311,9 @@ gateway {
   port: 7231
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg1-az1-x
+}
 EOF
 
 cat <<- EOF > "rg2-az2-x.conf"
@@ -305,6 +335,9 @@ gateway {
   port: 7232
   include gateway-routes.conf
 }
+jetstream: {
+  store_dir: /tmp/nats/storage/rg2-az2-x
+}
 EOF
 
 cat <<- EOF > "rg3-az3-x.conf"
@@ -325,6 +358,9 @@ gateway {
   name: xr
   port: 7233
   include gateway-routes.conf
+}
+jetstream: {
+  store_dir: /tmp/nats/storage/rg3-az3-x
 }
 EOF
 


### PR DESCRIPTION
The store_dir for each server in the example conflict at `/tmp/nats/jetstream'.
Furthermore, after nats-io/nats-server#4407 is merged these examples prior to this commit will produce an error.