### PR TITLE
Run cargo update in Rust dockerfile

### DIFF
--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -11,6 +11,7 @@ RUN echo "fn main(){}" > main.rs && cargo build
 RUN rm main.rs && rm /opt/app/target/debug/app
 COPY . .
 
+RUN cargo update
 RUN cargo build
 
 FROM debian:bullseye-slim


### PR DESCRIPTION
The pre-buffering dependency trick we do to cut a lot of compile time can possibly cause some weird caching in Docker where we do not want it. Cargo update hopefully fixes that with insignificant increase in build time.

All examples in preview have proper output.

 Signed-off-by: Tomasz Pietrek <tomasz@nats.io>