### PR TITLE
Adding elixir pubsub example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.elixir_ls/
 dist
 node_modules
 html

--- a/cmd/nbe/parse.go
+++ b/cmd/nbe/parse.go
@@ -64,6 +64,7 @@ var (
 		Crystal:   "main.cr",
 		DotNet:    "Main.cs",
 		DotNet2:   "Main.cs",
+		Elixir:    "main.exs",
 	}
 
 	languageMultiCommentDelims = map[string][2]string{

--- a/docker/elixir/Dockerfile
+++ b/docker/elixir/Dockerfile
@@ -1,0 +1,5 @@
+FROM elixir:1.15
+
+COPY . ./
+
+CMD ["elixir", "main.exs"]

--- a/examples/messaging/pub-sub/elixir/main.exs
+++ b/examples/messaging/pub-sub/elixir/main.exs
@@ -1,0 +1,87 @@
+# Set up the dependencies for this script. Ordinarily you would have this set of dependencies
+# declared in your `mix.exs` file.
+Mix.install([
+  # For documentation on the Gnat library, see https://hexdocs.pm/gnat/readme.html
+  {:gnat, "~> 1.6"},
+  {:jason, "~> 1.0"}
+])
+
+url = System.get_env("NATS_URL", "127.0.0.1")
+uri = URI.parse(url)
+
+# Call `start_link` on `Gnat` to start the Gnat application supervisor
+{:ok, gnat} = Gnat.start_link(%{host: uri.host, port: uri.port})
+
+# Manual subscriptions are easy and straightforward, just supply a topic and the target
+# pid to receive the `{:msg, m}` messages from the subscription.
+{:ok, subscription} = Gnat.sub(gnat, self(), "nbe.*")
+# Here we send a message to a subject that has a subscriber
+:ok = Gnat.pub(gnat, "nbe.news", "NATS by example is a great learning resource!")
+
+# In elixir, an explicit `receive` call blocks the current process until a message
+# arrives in its inbox. In this case, we're waiting for the `{:msg, m}` tuple from
+# the NATS client.
+receive do
+  {:msg, %{body: body, topic: "nbe.news", reply_to: nil}} ->
+    IO.puts("Manual subscription received: '#{body}'")
+end
+
+# Now let's move on to more resilient and production-grade ways of subscribing
+
+# In addition to one-off subscriptions, you can create a resilient consumer
+# supervisor that you intend to keep running for a long period of time that
+# will survive network partition events. This consumer supervisor can invoke
+# callbacks in a module that conforms to the `Gnat.Server` behavior, like this
+# `DemoServer` module.
+defmodule DemoServer do
+  use Gnat.Server
+
+  def request(%{body: body, topic: topic}) do
+    IO.puts("Received message on '#{topic}': '#{body}'")
+    :ok
+  end
+
+  # The error handler is an optional callback. `Gnat.Server` has a default one that you
+  # can use.
+  def error(%{gnat: gnat, reply_to: reply_to}, _error) do
+    Gnat.pub(gnat, reply_to, "Something went wrong and I can't handle your message")
+  end
+end
+
+# The `Gnat.ConnectionSupervisor` is a process that monitors your NATS connection. If connection
+# is lost, this process will retry according to its backoff settings to re-establish a connection.
+gnat_supervisor_settings = %{
+  name: :gnat,
+  backoff_period: 4_000,
+  connection_settings: [
+    %{host: uri.host, port: uri.port}
+  ]
+}
+{:ok, _conn} = Gnat.ConnectionSupervisor.start_link(gnat_supervisor_settings)
+
+# The connection supervisor's `start_link` establishes a connection asynchronously, so we need to
+# delay here until the connection is running. This isn't normally a problem when putting connection
+# supervisors into a supervision tree at startup
+if Process.whereis(:gnat) == nil do
+  Process.sleep(300)
+end
+
+# Consumer supervisors work in tandem with connection supervisors. The `connection_name` setting
+# refers to the name of a supervised connection, and not the `Gnat` application.
+consumer_supervisor_settings = %{
+  connection_name: :gnat,
+  # This is the module name of a module that exhibits the `Gnat.Server` behavior
+  module: DemoServer,
+  # We can subscribe on multiple topics, each of which can have wildcards
+  subscription_topics: [
+    %{topic: "rpc.demo", queue_group: "demo"},
+  ],
+}
+
+# In most applications the connection and consumer supervisors are started as part of the
+# supervision tree, but for this sample we just create it manually via `start_link`.
+{:ok, _sup} = Gnat.ConsumerSupervisor.start_link(consumer_supervisor_settings)
+IO.puts("Started consumer supervisor")
+
+# This publishes on the topic on which our consumer supervisor is listening.
+Gnat.pub(:gnat, "rpc.demo", "hello")

--- a/static/main.css
+++ b/static/main.css
@@ -9,8 +9,14 @@ body {
   flex-direction: column;
 }
 
-body, button, input, select, textarea {
-  font-family: "Source Sans Pro",BlinkMacSystemFont,-apple-system,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue","Helvetica","Arial",sans-serif;
+body,
+button,
+input,
+select,
+textarea {
+  font-family: "Source Sans Pro", BlinkMacSystemFont, -apple-system, "Segoe UI",
+    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 }
 
 h3 {
@@ -21,11 +27,13 @@ a {
   text-decoration: none;
 }
 
-a:link, a:visited {
+a:link,
+a:visited {
   color: #27aae1;
 }
 
-a:hover, a:active {
+a:hover,
+a:active {
   color: #375c93;
 }
 
@@ -123,7 +131,12 @@ footer {
   background-color: #efefef;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   color: #1b2e49;
 }
 
@@ -178,10 +191,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .info .language-tabs {
- /* width: 30%; */
+  /* width: 30%; */
 }
 
-.github-icon, .clipboard-icon {
+.github-icon,
+.clipboard-icon {
   width: 16px;
   display: inline-block;
   vertical-align: sub;
@@ -207,7 +221,8 @@ h1, h2, h3, h4, h5, h6 {
   color: #fff;
 }
 
-.info .language-tabs a:hover, .info .language-tabs a:active {
+.info .language-tabs a:hover,
+.info .language-tabs a:active {
   color: #fff;
 }
 
@@ -233,8 +248,10 @@ a:hover, a:active {
   background-color: inherit;
 }
 
-pre, code {
-  font-family: 'Roboto Mono', 'JetBrains Mono', 'Source Code Pro', 'FreeMono', monospace;
+pre,
+code {
+  font-family: "Roboto Mono", "JetBrains Mono", "Source Code Pro", "FreeMono",
+    monospace;
   font-size: 0.9em;
 }
 
@@ -284,64 +301,200 @@ pre, code {
 
 /* Syntax highlighting... */
 
-body .hll { background-color: #ffffcc }
-body .err { border: 1px solid #FF0000 }         /* Error */
-body .c  { color: #408080; font-style: italic } /* Comment */
-body .k  { color: #954121 }                     /* Keyword */
-body .o  { color: #666666 }                     /* Operator */
-body .cm { color: #408080; font-style: italic } /* Comment.Multiline */
-body .cp { color: #BC7A00 }                     /* Comment.Preproc */
-body .c1 { color: #408080; font-style: italic } /* Comment.Single */
-body .cs { color: #408080; font-style: italic } /* Comment.Special */
-body .gd { color: #A00000 }                     /* Generic.Deleted */
-body .ge { font-style: italic }                 /* Generic.Emph */
-body .gr { color: #FF0000 }                     /* Generic.Error */
-body .gh { color: #000080; font-weight: bold }  /* Generic.Heading */
-body .gi { color: #00A000 }                     /* Generic.Inserted */
-body .go { color: #808080 }                     /* Generic.Output */
-body .gp { color: #000080; font-weight: bold }  /* Generic.Prompt */
-body .gs { font-weight: bold }                  /* Generic.Strong */
-body .gu { color: #800080; font-weight: bold }  /* Generic.Subheading */
-body .gt { color: #0040D0 }                     /* Generic.Traceback */
-body .kc { color: #954121 }                     /* Keyword.Constant */
-body .kd { color: #954121 }                     /* Keyword.Declaration */
-body .kn { color: #954121 }                     /* Keyword.Namespace */
-body .kp { color: #954121 }                     /* Keyword.Pseudo */
-body .kr { color: #954121; font-weight: bold }  /* Keyword.Reserved */
-body .kt { color: #B00040 }                     /* Keyword.Type */
-body .m  { color: #666666 }                     /* Literal.Number */
-body .s  { color: #219161 }                     /* Literal.String */
-body .na { color: #7D9029 }                     /* Name.Attribute */
-body .nb { color: #954121 }                     /* Name.Builtin */
-body .nc { color: #0000FF; font-weight: bold }  /* Name.Class */
-body .no { color: #880000 }                     /* Name.Constant */
-body .nd { color: #AA22FF }                     /* Name.Decorator */
-body .ni { color: #999999; font-weight: bold }  /* Name.Entity */
-body .ne { color: #D2413A; font-weight: bold }  /* Name.Exception */
-body .nf {  }                     /* Name.Function */
-body .nl { color: #A0A000 }                     /* Name.Label */
-body .nn { color: #0000FF; font-weight: bold }  /* Name.Namespace */
-body .nt { color: #954121; font-weight: bold }  /* Name.Tag */
-body .nv { color: #19469D }                     /* Name.Variable */
-body .ow { color: #AA22FF; font-weight: bold }  /* Operator.Word */
-body .w  { color: #bbbbbb }                     /* Text.Whitespace */
-body .mf { color: #666666 }                     /* Literal.Number.Float */
-body .mh { color: #666666 }                     /* Literal.Number.Hex */
-body .mi { color: #666666 }                     /* Literal.Number.Integer */
-body .mo { color: #666666 }                     /* Literal.Number.Oct */
-body .sb { color: #219161 }                     /* Literal.String.Backtick */
-body .sc { color: #219161 }                     /* Literal.String.Char */
-body .sd { color: #219161; font-style: italic } /* Literal.String.Doc */
-body .s2 { color: #219161 }                     /* Literal.String.Double */
-body .se { color: #BB6622; font-weight: bold }  /* Literal.String.Escape */
-body .sh { color: #219161 }                     /* Literal.String.Heredoc */
-body .si { color: #BB6688; font-weight: bold }  /* Literal.String.Interpol */
-body .sx { color: #954121 }                     /* Literal.String.Other */
-body .sr { color: #BB6688 }                     /* Literal.String.Regex */
-body .s1 { color: #219161 }                     /* Literal.String.Single */
-body .ss { color: #19469D }                     /* Literal.String.Symbol */
-body .bp { color: #954121 }                     /* Name.Builtin.Pseudo */
-body .vc { color: #19469D }                     /* Name.Variable.Class */
-body .vg { color: #19469D }                     /* Name.Variable.Global */
-body .vi { color: #19469D }                     /* Name.Variable.Instance */
-body .il { color: #666666 }                     /* Literal.Number.Integer.Long */
+body .hll {
+  background-color: #ffffcc;
+}
+/*body .err { border: 1px solid #FF0000 }*/ /* Error */
+body .c {
+  color: #408080;
+  font-style: italic;
+} /* Comment */
+body .k {
+  color: #954121;
+} /* Keyword */
+body .o {
+  color: #666666;
+} /* Operator */
+body .cm {
+  color: #408080;
+  font-style: italic;
+} /* Comment.Multiline */
+body .cp {
+  color: #bc7a00;
+} /* Comment.Preproc */
+body .c1 {
+  color: #408080;
+  font-style: italic;
+} /* Comment.Single */
+body .cs {
+  color: #408080;
+  font-style: italic;
+} /* Comment.Special */
+body .gd {
+  color: #a00000;
+} /* Generic.Deleted */
+body .ge {
+  font-style: italic;
+} /* Generic.Emph */
+body .gr {
+  color: #ff0000;
+} /* Generic.Error */
+body .gh {
+  color: #000080;
+  font-weight: bold;
+} /* Generic.Heading */
+body .gi {
+  color: #00a000;
+} /* Generic.Inserted */
+body .go {
+  color: #808080;
+} /* Generic.Output */
+body .gp {
+  color: #000080;
+  font-weight: bold;
+} /* Generic.Prompt */
+body .gs {
+  font-weight: bold;
+} /* Generic.Strong */
+body .gu {
+  color: #800080;
+  font-weight: bold;
+} /* Generic.Subheading */
+body .gt {
+  color: #0040d0;
+} /* Generic.Traceback */
+body .kc {
+  color: #954121;
+} /* Keyword.Constant */
+body .kd {
+  color: #954121;
+} /* Keyword.Declaration */
+body .kn {
+  color: #954121;
+} /* Keyword.Namespace */
+body .kp {
+  color: #954121;
+} /* Keyword.Pseudo */
+body .kr {
+  color: #954121;
+  font-weight: bold;
+} /* Keyword.Reserved */
+body .kt {
+  color: #b00040;
+} /* Keyword.Type */
+body .m {
+  color: #666666;
+} /* Literal.Number */
+body .s {
+  color: #219161;
+} /* Literal.String */
+body .na {
+  color: #7d9029;
+} /* Name.Attribute */
+body .nb {
+  color: #954121;
+} /* Name.Builtin */
+body .nc {
+  color: #0000ff;
+  font-weight: bold;
+} /* Name.Class */
+body .no {
+  color: #880000;
+} /* Name.Constant */
+body .nd {
+  color: #aa22ff;
+} /* Name.Decorator */
+body .ni {
+  color: #999999;
+  font-weight: bold;
+} /* Name.Entity */
+body .ne {
+  color: #d2413a;
+  font-weight: bold;
+} /* Name.Exception */
+body .nf {
+} /* Name.Function */
+body .nl {
+  color: #a0a000;
+} /* Name.Label */
+body .nn {
+  color: #0000ff;
+  font-weight: bold;
+} /* Name.Namespace */
+body .nt {
+  color: #954121;
+  font-weight: bold;
+} /* Name.Tag */
+body .nv {
+  color: #19469d;
+} /* Name.Variable */
+body .ow {
+  color: #aa22ff;
+  font-weight: bold;
+} /* Operator.Word */
+body .w {
+  color: #bbbbbb;
+} /* Text.Whitespace */
+body .mf {
+  color: #666666;
+} /* Literal.Number.Float */
+body .mh {
+  color: #666666;
+} /* Literal.Number.Hex */
+body .mi {
+  color: #666666;
+} /* Literal.Number.Integer */
+body .mo {
+  color: #666666;
+} /* Literal.Number.Oct */
+body .sb {
+  color: #219161;
+} /* Literal.String.Backtick */
+body .sc {
+  color: #219161;
+} /* Literal.String.Char */
+body .sd {
+  color: #219161;
+  font-style: italic;
+} /* Literal.String.Doc */
+body .s2 {
+  color: #219161;
+} /* Literal.String.Double */
+body .se {
+  color: #bb6622;
+  font-weight: bold;
+} /* Literal.String.Escape */
+body .sh {
+  color: #219161;
+} /* Literal.String.Heredoc */
+body .si {
+  color: #bb6688;
+  font-weight: bold;
+} /* Literal.String.Interpol */
+body .sx {
+  color: #954121;
+} /* Literal.String.Other */
+body .sr {
+  color: #bb6688;
+} /* Literal.String.Regex */
+body .s1 {
+  color: #219161;
+} /* Literal.String.Single */
+body .ss {
+  color: #19469d;
+} /* Literal.String.Symbol */
+body .bp {
+  color: #954121;
+} /* Name.Builtin.Pseudo */
+body .vc {
+  color: #19469d;
+} /* Name.Variable.Class */
+body .vg {
+  color: #19469d;
+} /* Name.Variable.Global */
+body .vi {
+  color: #19469d;
+} /* Name.Variable.Instance */
+body .il {
+  color: #666666;
+} /* Literal.Number.Integer.Long */


### PR DESCRIPTION
This adds an elixir pubsub example. At the moment the console output is a bit long because the `.exs` script has its own managed dependencies rather than using a full-blown elixir application. At some point I'm going to do some experiments to see if we can move that dependency pull stuff into a build image so it doesn't show in the run image... but I figured having _something_ for Elixir here was better than waiting some unknown amount of time.