### PR TITLE
Remove un-needed into() call

### DIFF
--- a/examples/messaging/pub-sub/rust/main.rs
+++ b/examples/messaging/pub-sub/rust/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), async_nats::Error> {
 
     // Publish to three different subjects matching the wildcard.
     for subject in ["greet.sue", "greet.bob", "greet.pam"] {
-        client.publish(subject.into(), "hello".into()).await?;
+        client.publish(subject, "hello".into()).await?;
     }
 
     // Notice that the first message received is `greet.sue` and not


### PR DESCRIPTION
I believe this was missed in this commit
https://github.com/ConnectEverything/nats-by-example/pull/175/files