### PR TITLE
Improve confirmed ack Go example

### DIFF
--- a/examples/jetstream/ack-ack/go/main.go
+++ b/examples/jetstream/ack-ack/go/main.go
@@ -31,120 +31,68 @@ func main() {
 	// to streams and consuming messages from the streams.
 	js, _ := jetstream.New(nc)
 
-	// We will declare the initial stream configuration by specifying
-	// the name and subjects. Stream names are commonly uppercase to
-	// visually differentiate them from subjects, but this is not required.
-	// A stream can bind one or more subjects which almost always include
-	// wildcards. In addition, no two streams can have overlapping subjects
-	// otherwise the primary messages would be persisted twice. There
-	// are options to replicate messages in various ways, but that will
-	// be explained in later examples.
-	cfg := jetstream.StreamConfig{
-		Name:     "DOUBLE_ACK_STREAM",
-		Subjects: []string{"doubleAckSubject"},
-		Storage:  jetstream.MemoryStorage,
-	}
-
 	// JetStream API uses context for timeouts and cancellation.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Delete the stream, so we always have a fresh start for the example
-	// don't care if this, errors in this example, it will if the stream exists.
-	_ = js.DeleteStream(ctx, "DOUBLE_ACK_STREAM")
+	// Create a stream.
+	// Any stream can work with confirmed acks.
+	stream, _ := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "STREAM",
+		Subjects: []string{"data"},
+		Storage:  jetstream.MemoryStorage,
+	})
 
-	// Let's add/create the stream with the default (no) limits.
-	stream, _ := js.CreateStream(ctx, cfg)
+	// Publish a couple messages.
+	js.Publish(ctx, "data", []byte("A"))
+	js.Publish(ctx, "data", []byte("B"))
 
-	// Publish a couple messages, so we can look at the state. In a real system we might ensure there is no error.
-	_, err := js.Publish(ctx, "doubleAckSubject", []byte("A"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	_, err = js.Publish(ctx, "doubleAckSubject", []byte("B"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Consume a message with 2 different consumers
-	// The first consumer will Ack without confirmation
-	// The second consumer will AckSync which confirms that ack was handled.
-	cons1, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Durable:       "Consumer1",
-		FilterSubject: "doubleAckSubject",
+	// Create a consumer with explicit ack policy.
+	consumer, _ := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Name:          "CONSUMER",
+		FilterSubject: "data",
 		AckPolicy:     jetstream.AckExplicitPolicy,
 	})
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	cons2, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Durable:       "Consumer2",
-		FilterSubject: "doubleAckSubject",
-		AckPolicy:     jetstream.AckExplicitPolicy,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
+	ci, _ := consumer.Info(ctx)
 
-	// Consumer 1 will use Ack()
-	ci, err := cons1.Info(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println("Consumer 1")
 	fmt.Printf("  Start\n    # pending messages: %d\n    # messages with ack pending: %d\n", ci.NumPending, ci.NumAckPending)
 
-	// Get one message with Consumer Next()
-	m, err := cons1.Next()
-	if err != nil {
-		log.Fatal(err)
-	}
-	ci, err = cons1.Info(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Get the next pending message for the consumer.
+	m, _ := consumer.Next()
+
+	// Fetch the state of the consumer.
+	ci, _ = consumer.Info(ctx)
 	fmt.Printf("  After received but before ack\n    # pending messages: %d\n    # messages with ack pending: %d\n", ci.NumPending, ci.NumAckPending)
 
 	// Ack the message.
-	err = m.Ack()
+	// We're using standard ack here, which does not wait for the server to confirm it received it.
+	// If server is experiencing high load, or the connection is severed before the ack is received, the ack can be lost, leading to a redelivery.
+	err := m.Ack()
+	// Error here only means that the client failed to send the ack message.
+	// There will be no error if the client published the ack, but the server did not receive (or process) it.
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	ci, _ = consumer.Info(ctx)
 	fmt.Printf("  After ack\n    # pending messages: %d\n    # messages with ack pending: %d\n", ci.NumPending, ci.NumAckPending)
 
-	// Consumer 2 will use DoubleAck()
-	ci, err = cons2.Info(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Get the next pending message for the consumer.
+	m, _ = consumer.Next()
 
-	fmt.Println("Consumer 2")
-	fmt.Printf("  Start\n    # pending messages: %d\n    # messages with ack pending: %d\n", ci.NumPending, ci.NumAckPending)
-
-	// Get one message with Consumer Next()
-	m, err = cons2.Next()
-	if err != nil {
-		log.Fatal(err)
-	}
-	ci, err = cons2.Info(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Fetch the state of the consumer.
+	ci, _ = consumer.Info(ctx)
 	fmt.Printf("  After received but before ack\n    # pending messages: %d\n    # messages with ack pending: %d\n", ci.NumPending, ci.NumAckPending)
-
-	// DoubleAck the message.
-	// The thing about DoubleAck is it is a request reply.
-	// Make a request to the server, the server does work, the server replies.
-	// It's rare, but the request could get to the server,
-	// the server handles it and sends the response, but it
-	// does not make it back to the client in time. This is where
-	// knowledge of the environment and network is important
-	// when setting connection and request time-outs.
+	// Here we use confirmed ack.
+	// This one will wait for the server to confirm that the ack was received and processed.
+	// It allows us to react to the ack being lost by sending it again, potentially avoiding redelivery.
 	err = m.DoubleAck(ctx)
+	// This error can mean that the ack was failed to be send, or that the server failed to confirm it.
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	ci, _ = consumer.Info(ctx)
 	fmt.Printf("  After ack\n    # pending messages: %d\n    # messages with ack pending: %d\n", ci.NumPending, ci.NumAckPending)
 }


### PR DESCRIPTION
The previous version had few things that could be improved:
1. Unnecessary details on stream, which are outlined in stream examples.
2. Explicitly handling errors, while other examples ignore them for easier readability.
3. Example was not fetching fresh info, which then printed that the ack was not yet processed, which was not true.
4. Added more explanation on difference between ack and confirmed ack.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>