### PR TITLE
Fix queue group link in Concurrent Message Processing example

### DIFF
--- a/examples/messaging/concurrent/meta.yaml
+++ b/examples/messaging/concurrent/meta.yaml
@@ -2,7 +2,7 @@ title: Concurrent Message Processing
 description: |-
   By default, when a subscription is created, each message that is
   received it process sequentially. There can be multiple subscriptions
-  setup in a [queue group][queue] in which case the NATS server will
+  setup in a [queue group][1] in which case the NATS server will
   distribute messages to each member of the group.
 
   However, even within a subscription, it may be desirable to handle


### PR DESCRIPTION
Fix link for queue group in [Concurrent Message Processing](https://natsbyexample.com/examples/messaging/concurrent/python)

Before:

> By default, when a subscription is created, each message that is received it process sequentially. There can be multiple subscriptions setup in a [queue group][queue] in which case the NATS server will distribute messages to each member of the group.

After:

> By default, when a subscription is created, each message that is received it process sequentially. There can be multiple subscriptions setup in a [queue group](https://docs.nats.io/nats-concepts/core-nats/queue) in which case the NATS server will distribute messages to each member of the group.