### PR TITLE
Make nats-server start up in cli pub-sub example

### DIFF
--- a/examples/messaging/pub-sub/cli/main.sh
+++ b/examples/messaging/pub-sub/cli/main.sh
@@ -7,6 +7,11 @@
 # ```
 # nats context save --server=$NATS_URL local
 # ```
+
+
+# Start a nats-server in the background.
+nats-server &
+
 NATS_URL="${NATS_URL:-nats://localhost:4222}"
 
 # Publish a message to the subject 'greet.joe'. Nothing will happen


### PR DESCRIPTION
It looks like the nats-server was already installed in the Dockerfile but never actually started in the script. I added a line to start it up in the background at the beginning of the script. 