### PR TITLE
Use nbe genereate --recreate in githhub action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Generate recordings
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          nbe generate recording --exit-on-error
+          nbe generate recording --exit-on-error --recreate
 
       - name: Auto-commit generated recordings
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
After removing all the outputs:
```
find . -name output.cast -or  -name output.txt | xargs rm
nbe generate recording   --recreate
```
I see that the following files are not recreated, meaning the examples are failing to build or regeneration is not happening for some other reason...:
```
[alex@omenlaptop nats-by-example]$ git status | grep deleted | grep \.txt
        deleted:    examples/auth/nkeys-jwts/go/output.txt
        deleted:    examples/embedded/mtls/go/output.txt
        deleted:    examples/jetstream/ack-ack/csharp/output.txt
        deleted:    examples/jetstream/ack-ack/go/output.txt
        deleted:    examples/jetstream/api-migration/dotnet/output.txt
        deleted:    examples/jetstream/api-migration/go/output.txt
        deleted:    examples/jetstream/interest-stream/csharp/output.txt
        deleted:    examples/jetstream/interest-stream/go/output.txt
        deleted:    examples/jetstream/limits-stream/csharp/output.txt
        deleted:    examples/jetstream/limits-stream/go/output.txt
        deleted:    examples/jetstream/limits-stream/node/output.txt
        deleted:    examples/jetstream/limits-stream/rust/output.txt
        deleted:    examples/jetstream/list-subjects/csharp/output.txt
        deleted:    examples/jetstream/list-subjects/go/output.txt
        deleted:    examples/jetstream/pull-consumer-limits/csharp/output.txt
        deleted:    examples/jetstream/pull-consumer-limits/go/output.txt
        deleted:    examples/jetstream/pull-consumer/csharp/output.txt
        deleted:    examples/jetstream/pull-consumer/go/output.txt
        deleted:    examples/jetstream/workqueue-stream/csharp/output.txt
        deleted:    examples/jetstream/workqueue-stream/go/output.txt
        deleted:    examples/kv/intro/csharp/output.txt
        deleted:    examples/kv/intro/go/output.txt
        deleted:    examples/messaging/concurrent/csharp/output.txt
        deleted:    examples/messaging/iterating-multiple-subscriptions/csharp/output.txt
        deleted:    examples/messaging/json/csharp/output.txt
        deleted:    examples/messaging/protobuf/csharp/output.txt
        deleted:    examples/messaging/pub-sub/csharp/output.txt
        deleted:    examples/messaging/pub-sub/node/output.txt
        deleted:    examples/messaging/request-reply/csharp/output.txt
        deleted:    examples/os/intro/csharp/output.txt
        deleted:    examples/services/intro/csharp/output.txt
```

This change will trigger image rebuild and will exercise all the examples to catch broken builds.

When --exit-on-error was added in 
https://github.com/ConnectEverything/nats-by-example/pull/81/files by @scottf 
was the idea to use the generate command as a way of running tests?